### PR TITLE
Fix parser discarding original header attributes

### DIFF
--- a/lib/asciidoctor-bibliography/asciidoctor.rb
+++ b/lib/asciidoctor-bibliography/asciidoctor.rb
@@ -1,17 +1,11 @@
 require 'asciidoctor/extensions'
 
 require_relative 'asciidoctor/bibliographer_preprocessor'
+require_relative 'asciidoctor/document_ext'
 require_relative 'bibliographer'
+
+Asciidoctor::Document.include AsciidoctorBibliography::Asciidoctor::DocumentExt
 
 Asciidoctor::Extensions.register do
   preprocessor AsciidoctorBibliography::Asciidoctor::BibliographerPreprocessor
-end
-
-module Asciidoctor
-  class Document
-    # All our document-level permanence passes through this attribute accessor.
-    def bibliographer
-      @bibliographer ||= AsciidoctorBibliography::Bibliographer.new
-    end
-  end
 end

--- a/lib/asciidoctor-bibliography/asciidoctor/bibliographer_preprocessor.rb
+++ b/lib/asciidoctor-bibliography/asciidoctor/bibliographer_preprocessor.rb
@@ -1,4 +1,5 @@
 require 'asciidoctor'
+require 'pp'
 
 require_relative '../helpers'
 require_relative '../database'
@@ -70,14 +71,21 @@ module AsciidoctorBibliography
       def set_bibliographer_options(document, reader)
         # We peek at the document attributes we need, without perturbing the parsing flow.
         # NOTE: we're in a preprocessor and they haven't been parsed yet; doing it manually.
+        # pp reader
         header_attributes = extract_header_attributes reader
         user_options = filter_bibliography_attributes header_attributes
         document.bibliographer.options = OPTIONS_DEFAULTS.merge user_options
       end
 
       def extract_header_attributes(reader)
+        tdoc = ::Asciidoctor::Document.new
+        treader = ::Asciidoctor::PreprocessorReader.new(
+          tdoc,
+          reader.source_lines
+        )
+
         ::Asciidoctor::Parser
-          .parse(reader, ::Asciidoctor::Document.new, header_only: true)
+          .parse(treader, tdoc, header_only: true)
           .attributes
       end
 

--- a/lib/asciidoctor-bibliography/asciidoctor/document_ext.rb
+++ b/lib/asciidoctor-bibliography/asciidoctor/document_ext.rb
@@ -1,0 +1,11 @@
+# Extends Document to support additional method
+module AsciidoctorBibliography
+  module Asciidoctor
+    module DocumentExt
+      # All our document-level permanence passes through this accessor.
+      def bibliographer
+        @bibliographer ||= AsciidoctorBibliography::Bibliographer.new
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously other header attributes (title, toc, etc) will be missing due to this code:

```ruby
def extract_header_attributes(reader)
  ::Asciidoctor::Parser
  .parse(reader, ::Asciidoctor::Document.new, header_only: true)
  .attributes
```

The reason is that `reader` is shared by our gem and the original `Asciidoctor::Document`. In the gem if we first use parser to read all headers, the original `Document` no longer parses them because the `reader`'s Cursor has already advanced past the header.

Therefore we use a newly created trio of the `Document`, `Reader` and `Parser` to achieve this parsing here.