### PR TITLE
Globs on `bibliography-database`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -199,6 +199,13 @@ Currently only the `BibTeX` format is supported, with `.bib` or `.bibtex` extens
 are safe to use: unknown attributes will be silently ignored. If the file has `.biblatex`
 extension the you will receive a warning on compilation.
 
+If you need to include multipla databases, you can simply list their names.
+Wildcards are allowed too:
+
+[source,asciidoc]
+----
+:bibliography-database: db1.bib db2.bib ../dbs/*.bibtex
+----
 
 === Styling
 

--- a/README.adoc
+++ b/README.adoc
@@ -199,7 +199,7 @@ Currently only the `BibTeX` format is supported, with `.bib` or `.bibtex` extens
 are safe to use: unknown attributes will be silently ignored. If the file has `.biblatex`
 extension the you will receive a warning on compilation.
 
-If you need to include multipla databases, you can simply list their names.
+If you need to include multiple databases, you can simply list their names.
 Wildcards are allowed too:
 
 [source,asciidoc]

--- a/lib/asciidoctor-bibliography/asciidoctor/bibliographer_preprocessor.rb
+++ b/lib/asciidoctor-bibliography/asciidoctor/bibliographer_preprocessor.rb
@@ -12,12 +12,8 @@ module AsciidoctorBibliography
         document.bibliographer.options =
           ::AsciidoctorBibliography::Options.build document, reader
 
-        database_filepath =
-          File.expand_path document.bibliographer.options.database,
-                           document.base_dir
-
         document.bibliographer.database =
-          ::AsciidoctorBibliography::Database.new database_filepath
+          ::AsciidoctorBibliography::Database.new *expand_db_globs(document)
 
         processed_lines = process_lines reader.read_lines, document.bibliographer
         reader.unshift_lines processed_lines
@@ -61,6 +57,19 @@ module AsciidoctorBibliography
           else
             line
           end
+        end.flatten
+      end
+
+      def expand_db_globs(document)
+        glob_pattern(
+          document.bibliographer.options.database,
+          document.base_dir,
+        )
+      end
+
+      def glob_pattern(pattern_string, base_dir)
+        pattern_string.split(/(?<!\\)\s+/).map do |pattern|
+          Dir.chdir(base_dir) { Dir.glob(pattern) }
         end.flatten
       end
     end

--- a/lib/asciidoctor-bibliography/database.rb
+++ b/lib/asciidoctor-bibliography/database.rb
@@ -13,6 +13,8 @@ module AsciidoctorBibliography
 
     def append(filepath)
       concat Database.load(filepath)
+      ensure_no_conflicts!
+      self
     end
 
     def find_entry_by_id(id)
@@ -36,6 +38,16 @@ module AsciidoctorBibliography
       else
         raise Errors::Database::UnsupportedFormat, fileext
       end
+    end
+
+    private
+
+    def ensure_no_conflicts!
+      ids = map { |entry| entry["id"] }
+      conflicting_ids = ids.select { |id| ids.count(id) > 1 }.uniq.sort
+      raise Errors::Database::ConflictingIds, <<~MESSAGE if conflicting_ids.any?
+        Conflicting ids were found during database import: #{conflicting_ids}.
+      MESSAGE
     end
   end
 end

--- a/lib/asciidoctor-bibliography/errors.rb
+++ b/lib/asciidoctor-bibliography/errors.rb
@@ -11,6 +11,7 @@ module AsciidoctorBibliography
       class UnsupportedFormat < Error; end
       class FileNotFound < Error; end
       class IdNotFound < Error; end
+      class ConflictingIds < Error; end
     end
   end
 end

--- a/lib/asciidoctor-bibliography/version.rb
+++ b/lib/asciidoctor-bibliography/version.rb
@@ -1,3 +1,3 @@
 module AsciidoctorBibliography
-  VERSION = "0.7.3".freeze
+  VERSION = "0.8.0".freeze
 end

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -42,6 +42,12 @@ describe AsciidoctorBibliography::Database do
       expect { db.append("spec/fixtures/database.bib") }.to(change { db.length })
       expect { db.append("spec/fixtures/database.bibtex") }.to(change { db.length })
     end
+
+    it "raises error if conflicting ids are found" do
+      db.append("spec/fixtures/database.bib")
+      expect { db.append("spec/fixtures/database.bib") }.
+        to raise_exception AsciidoctorBibliography::Errors::Database::ConflictingIds
+    end
   end
 
   describe ".load" do


### PR DESCRIPTION
This closes #67, introduces the feature and bumps a minor to `v0.8.0`
The `AsciidoctorBibliography::Database` already allowed initialization with multiple files, so it was just a matter of expanding the globs.
I added a hard check that halts compilation if conflicting ids are found among the imported databases.
An error message is shown and they are printed out.