### PR TITLE
Support cites in footnotes, via double-angle-bracket xref format

### DIFF
--- a/lib/asciidoctor-bibliography/citation.rb
+++ b/lib/asciidoctor-bibliography/citation.rb
@@ -75,8 +75,8 @@ module AsciidoctorBibliography
       formatted_citation
     end
 
-    def un_curlybrace!(str)
-      str.gsub!(/{{{(?<xref_label>.*?)}}}/) do
+    def un_curlybrace!(string)
+      string.gsub!(/{{{(?<xref_label>.*?)}}}/) do
         ["<<", Regexp.last_match[:xref_label], ">>"].join
       end
     end

--- a/lib/asciidoctor-bibliography/citation.rb
+++ b/lib/asciidoctor-bibliography/citation.rb
@@ -119,24 +119,18 @@ module AsciidoctorBibliography
       item.prefix = prefix.to_s + item.prefix.to_s
       item.suffix = item.suffix.to_s + suffix.to_s
     end
-    
-    def escape_commas! (str)
-      idx = str.index(',')
-      str.gsub!(',', '&#44;')
-	  # Now, must re-insert the FIRST comma it replaced
-	  # but, first cater for any '&#44;' that had been embedded in targeted item.id:
-      idx2 = str.index('&#44;')
+
+    def escape_commas!(str)
+      idx = str.index(",")
+      str.gsub!(",", "&#44;")
+      idx2 = str.index("&#44;")
       until idx2 == idx
-        str.sub!('&#44;', '___my_very_odd_STR!NG_indeedy___')
-        idx2 = str.index('&#44;')
+        str.sub!("&#44;", "___my_very_odd_STR!NG_indeedy___")
+        idx2 = str.index("&#44;")
       end
-	  # re-insert first comma
-      str.sub!('&#44;', ',')
-	  # clean up
-      str.gsub!('___my_very_odd_STR!NG_indeedy___', '&#44;')
-      str.gsub!(/{{{(?<xref_label>.*?)}}}/) do
-        ["<<", Regexp.last_match[:xref_label], ">>"].join
-      end
+      str.sub!("&#44;", ",")
+      str.gsub!("___my_very_odd_STR!NG_indeedy___", "&#44;")
+      str.gsub!(/{{{(?<xref_label>.*?)}}}/) { ["<<", Regexp.last_match[:xref_label], ">>"].join }
     end
 
     def uuid

--- a/lib/asciidoctor-bibliography/citation.rb
+++ b/lib/asciidoctor-bibliography/citation.rb
@@ -126,19 +126,6 @@ module AsciidoctorBibliography
       end
     end
 
-    def escape_commas(str)
-      idx = str.index(",")
-      str.gsub!(",", "&#44;")
-      idx2 = str.index("&#44;")
-      until idx2 == idx
-        str.sub!("&#44;", "___my_very_odd_STR!NG_indeedy___")
-        idx2 = str.index("&#44;")
-      end
-      str.sub!("&#44;", ",")
-      str.gsub!("___my_very_odd_STR!NG_indeedy___", "&#44;")
-      str
-    end
-
     def uuid
       ":#{@uuid}:"
     end

--- a/lib/asciidoctor-bibliography/citation.rb
+++ b/lib/asciidoctor-bibliography/citation.rb
@@ -70,18 +70,9 @@ module AsciidoctorBibliography
       formatter = Formatter.new(style, locale: bibliographer.options.locale)
       items = prepare_items bibliographer, formatter, tex: tex
       formatted_citation = formatter.engine.renderer.render(items, formatter.engine.style.citation)
-      # Andy's new method--to replace escape_brackets_inside_xref!
       escape_commas! formatted_citation
-      #escape_brackets_inside_xref! formatted_citation
       interpolate_formatted_citation! formatted_citation
       formatted_citation
-    end
-
-# Not using this, since Andy's emendation (see above)
-    def escape_brackets_inside_xref!(string)
-      string.gsub!(/{{{(?<xref_label>.*?)}}}/) do
-        ["[", Regexp.last_match[:xref_label].gsub("]", '\]'), "]"].join
-      end
     end
 
     def interpolate_formatted_citation!(formatted_citation)
@@ -120,7 +111,7 @@ module AsciidoctorBibliography
       wrap_item item, ci.prefix, ci.suffix if affix
       id = xref_id "bibliography", ci.target, item.id
       wrap_item item, "___#{item.id}___", "___/#{item.id}___"
-      wrap_item item, "{{{#{id},", "}}}" if options.hyperlinks?    # Andy changed this line
+      wrap_item item, "{{{#{id},", "}}}" if options.hyperlinks?
       item.label, item.locator = ci.locator
     end
 
@@ -129,13 +120,12 @@ module AsciidoctorBibliography
       item.suffix = item.suffix.to_s + suffix.to_s
     end
     
-    # Andy's new method
     def escape_commas! (str)
       cypher = nil
       idx = str.index(',')
       cypher = str.gsub!(',', '&#44;')
 	  # Now, must re-insert the FIRST comma it replaced
-	  # but, must first cater for any '&#44;' that had been embedded in targeted item.id:
+	  # but, first cater for any '&#44;' that had been embedded in targeted item.id:
       idx2 = str.index('&#44;')
       until idx2 == idx
         str.sub!('&#44;', '___my_very_odd_STR!NG_indeedy___')

--- a/lib/asciidoctor-bibliography/citation.rb
+++ b/lib/asciidoctor-bibliography/citation.rb
@@ -122,7 +122,7 @@ module AsciidoctorBibliography
 
     def un_curlybrace!(str)
       str.gsub!(/{{{(?<xref_label>.*?)}}}/) do
-        ["<<", escape_commas(Regexp.last_match[:xref_label].to_s), ">>"].join
+        ["<<", Regexp.last_match[:xref_label], ">>"].join
       end
     end
 

--- a/lib/asciidoctor-bibliography/citation.rb
+++ b/lib/asciidoctor-bibliography/citation.rb
@@ -75,6 +75,12 @@ module AsciidoctorBibliography
       formatted_citation
     end
 
+    def un_curlybrace!(str)
+      str.gsub!(/{{{(?<xref_label>.*?)}}}/) do
+        ["<<", Regexp.last_match[:xref_label], ">>"].join
+      end
+    end
+
     def interpolate_formatted_citation!(formatted_citation)
       citation_items.each do |citation_item|
         key = Regexp.escape citation_item.key
@@ -118,12 +124,6 @@ module AsciidoctorBibliography
     def wrap_item(item, prefix, suffix)
       item.prefix = prefix.to_s + item.prefix.to_s
       item.suffix = item.suffix.to_s + suffix.to_s
-    end
-
-    def un_curlybrace!(str)
-      str.gsub!(/{{{(?<xref_label>.*?)}}}/) do
-        ["<<", Regexp.last_match[:xref_label], ">>"].join
-      end
     end
 
     def uuid

--- a/lib/asciidoctor-bibliography/citation.rb
+++ b/lib/asciidoctor-bibliography/citation.rb
@@ -70,7 +70,7 @@ module AsciidoctorBibliography
       formatter = Formatter.new(style, locale: bibliographer.options.locale)
       items = prepare_items bibliographer, formatter, tex: tex
       formatted_citation = formatter.engine.renderer.render(items, formatter.engine.style.citation)
-      escape_commas! formatted_citation
+      un_curlybrace! formatted_citation
       interpolate_formatted_citation! formatted_citation
       formatted_citation
     end
@@ -120,7 +120,13 @@ module AsciidoctorBibliography
       item.suffix = item.suffix.to_s + suffix.to_s
     end
 
-    def escape_commas!(str)
+    def un_curlybrace!(str)
+      str.gsub!(/{{{(?<xref_label>.*?)}}}/) do
+        ["<<", escape_commas(Regexp.last_match[:xref_label].to_s), ">>"].join 
+      end
+    end
+
+    def escape_commas(str)
       idx = str.index(",")
       str.gsub!(",", "&#44;")
       idx2 = str.index("&#44;")
@@ -130,7 +136,7 @@ module AsciidoctorBibliography
       end
       str.sub!("&#44;", ",")
       str.gsub!("___my_very_odd_STR!NG_indeedy___", "&#44;")
-      str.gsub!(/{{{(?<xref_label>.*?)}}}/) { ["<<", Regexp.last_match[:xref_label], ">>"].join }
+      str
     end
 
     def uuid

--- a/lib/asciidoctor-bibliography/citation.rb
+++ b/lib/asciidoctor-bibliography/citation.rb
@@ -121,9 +121,8 @@ module AsciidoctorBibliography
     end
     
     def escape_commas! (str)
-      cypher = nil
       idx = str.index(',')
-      cypher = str.gsub!(',', '&#44;')
+      str.gsub!(',', '&#44;')
 	  # Now, must re-insert the FIRST comma it replaced
 	  # but, first cater for any '&#44;' that had been embedded in targeted item.id:
       idx2 = str.index('&#44;')
@@ -132,13 +131,12 @@ module AsciidoctorBibliography
         idx2 = str.index('&#44;')
       end
 	  # re-insert first comma
-      cypher = str.sub!('&#44;', ',')
+      str.sub!('&#44;', ',')
 	  # clean up
       str.gsub!('___my_very_odd_STR!NG_indeedy___', '&#44;')
-      cypher = str.gsub!(/{{{(?<xref_label>.*?)}}}/) do
+      str.gsub!(/{{{(?<xref_label>.*?)}}}/) do
         ["<<", Regexp.last_match[:xref_label], ">>"].join
       end
-      cypher
     end
 
     def uuid

--- a/lib/asciidoctor-bibliography/citation.rb
+++ b/lib/asciidoctor-bibliography/citation.rb
@@ -122,7 +122,7 @@ module AsciidoctorBibliography
 
     def un_curlybrace!(str)
       str.gsub!(/{{{(?<xref_label>.*?)}}}/) do
-        ["<<", escape_commas(Regexp.last_match[:xref_label].to_s), ">>"].join 
+        ["<<", escape_commas(Regexp.last_match[:xref_label].to_s), ">>"].join
       end
     end
 


### PR DESCRIPTION
Issue #78 asks for asciidoctor-bibliography to work with cites in footnotes. Given Asciidoctor's current functionality, and given this extension's architecture as a Preprocessor, working correctly with cites in footnotes will be problematic so long as the extension uses the square-bracketed, `xref:targetID[citation-text]` form of xrefs.

The double-angle-bracketed, `<<targetID,citation-text>>` form of xref is the form that asciidoctor-bibtex uses; which is why the latter extension handles cites in footnotes. I have not found any impairment of functionality, or other disadvantage whatsoever to changing asciidoctor-bibliography to do likewise. This would resolve Issue #78.