### PR TITLE
Fix issue where including bibliography macro without using any citations throws error

### DIFF
--- a/lib/asciidoctor-bibliography/index.rb
+++ b/lib/asciidoctor-bibliography/index.rb
@@ -50,9 +50,9 @@ module AsciidoctorBibliography
 
     def prepare_filtered_db(bibliographer)
       if bibliographer.occurring_keys.include? target
-         bibliographer.occurring_keys[target].
-           map { |id| bibliographer.database.find_entry_by_id(id) }.
-           map { |entry| prepare_entry_metadata bibliographer, entry }
+        bibliographer.occurring_keys[target].
+          map { |id| bibliographer.database.find_entry_by_id(id) }.
+          map { |entry| prepare_entry_metadata bibliographer, entry }
       else {}
       end
     end

--- a/lib/asciidoctor-bibliography/index.rb
+++ b/lib/asciidoctor-bibliography/index.rb
@@ -49,9 +49,12 @@ module AsciidoctorBibliography
     end
 
     def prepare_filtered_db(bibliographer)
-      bibliographer.occurring_keys[target].
-        map { |id| bibliographer.database.find_entry_by_id(id) }.
-        map { |entry| prepare_entry_metadata bibliographer, entry }
+      if bibliographer.occurring_keys.include? target
+         bibliographer.occurring_keys[target].
+           map { |id| bibliographer.database.find_entry_by_id(id) }.
+           map { |entry| prepare_entry_metadata bibliographer, entry }
+      else {}
+      end
     end
 
     def prepare_entry_metadata(bibliographer, entry)

--- a/spec/index_spec.rb
+++ b/spec/index_spec.rb
@@ -1,0 +1,15 @@
+# coding: utf-8
+
+require_relative "citation_helper"
+
+describe AsciidoctorBibliography::Index do
+    describe ".render" do
+        subject { described_class.new([], "default", "") }
+
+        it "does not fail when no citations occur in the document" do
+            options = { "bibliography-style" => "ieee", "bibliography-database" => "database.bibtex", "bibliography-passthrough" => "true", "bibliography-prepend-empty" => "false" }
+            bibliographer = init_bibliographer options: options
+            expect { subject.render bibliographer}.to_not raise_exception
+        end
+    end
+end


### PR DESCRIPTION
This is a fix for issue #82 I just made.

I chose to make the change in [index.rb](https://github.com/riboseinc/asciidoctor-bibliography/blob/master/lib/asciidoctor-bibliography/index.rb) (rather than earlier by checking if the bibliographer's `occuring_keys` map is empty, say for example [here](https://github.com/riboseinc/asciidoctor-bibliography/blob/master/lib/asciidoctor-bibliography/asciidoctor/bibliographer_preprocessor.rb#L27)) because the preprocessor still needs to remove the `bibliography::[]` line when [rendering indices](https://github.com/riboseinc/asciidoctor-bibliography/blob/master/lib/asciidoctor-bibliography/asciidoctor/bibliographer_preprocessor.rb#L56) for the final output.

I made a small test to isolate where the problem occurs. With this fix, I can successfully compile .adoc that have the `bibliography` macro even if no citations are used.