### PR TITLE
Say that :bibliography-style: controls bibl. style

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -344,7 +344,7 @@ You can set their style in the header:
 Accepted values are `authoryear` (default) and `numeric`.
 
 IMPORTANT: The `cite` macro and the `cite...` macros described in this section are completely
-independent mechanisms. The former is styled with `:bibliography-style:` (thousands of styles available)
+independent mechanisms. The former, along with the bibliography, is styled with `:bibliography-style:` (thousands of styles available)
 while the latter is styled with with `:bibliography-tex-style:` (much more limited, only has the
 styles listed above).
 


### PR DESCRIPTION
Nowhere in the README.adoc is there currently a mention that the reference-styling is controlled by :bibliography-style: only (i.e., :bibliography-tex-style: has _nothing_ to do with it, even if all your cites are using the "Tex-mode" macros).