### PR TITLE
Added nocite macro for phantom citations

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -327,6 +327,7 @@ and can be used with a few styles:
 * `citeauthor*`
 * `citeyear`
 * `citeyearpar`
+* `nocite`
 
 To cite multiple items you can concatenate them just like with `cite`.
 

--- a/lib/asciidoctor-bibliography/citation.rb
+++ b/lib/asciidoctor-bibliography/citation.rb
@@ -7,7 +7,7 @@ require "csl/styles"
 module AsciidoctorBibliography
   class Citation
     TEX_MACROS = %w[citet citet* citealt citealt* citep citep* citealp citealp*
-                    citeauthor citeauthor* citeyear citeyearpar].freeze
+                    citeauthor citeauthor* citeyear citeyearpar nocite].freeze
 
     MACRO_NAME_REGEXP = TEX_MACROS.dup.concat(%w[cite fullcite]).
       map { |s| Regexp.escape s }.join("|").freeze
@@ -61,6 +61,8 @@ module AsciidoctorBibliography
         render_citation_with_csl(bibliographer)
       when "fullcite"
         render_fullcite_with_csl(bibliographer)
+      when "nocite"
+        ""
       when *TEX_MACROS
         render_texmacro_with_csl(bibliographer)
       end


### PR DESCRIPTION
Hey,

I just stumpled upon this **fantastic** gem. I worked quite a bit on the asciidoctor-bibtex source in my own [fork](https://github.com/Fiech/asciidoctor-bibtex) to get some of features (namely locale support, freely configurable locators and intermediate bibliographies) in, just to find out that your project already has implemented these (if I just've known...).

I now added a `nocite` macro (which would be my next  feature addition for asciidoctor-bibtex) for these times you want to have something listed in the bibliography without explicitly citing them as text.

I have to admit, that I just found your code maybe half an hour ago and I do not yet fully grasp your structure, neither why `nocite` does not work, if it's not in the `TEX_MACRO` variable. So I did extend the `case` statement to _catch_ the nocite before it goes into the `render_texmacro_with_csl` method. Well anyway, it does just work, even with `bibliography::foo[]` structure.

I am a bit surprised that it does, to be honest, without any faff... But maybe you can tell me a) why this works this way this and not without the inclusion in `TEX_MACRO` , b) if this is even a good way to implement this, and c) if there is a better way to do this altogether.

Maybe you're even inclined to accept the merge request. Seems to work just fine with me.

Best,
Johannes