### PR TITLE
Relax asciidoctor dependency requirements

### DIFF
--- a/asciidoctor-bibliography.gemspec
+++ b/asciidoctor-bibliography.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.test_files    = `git ls-files -- {spec}/*`.split("\n")
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
-  spec.add_dependency "asciidoctor", "~> 1.5.6"
+  spec.add_dependency "asciidoctor", ">= 1.5.6"
   spec.add_dependency "bibtex-ruby", "~> 4.4.4"
   spec.add_dependency "citeproc-ruby", "~> 1.1.7"
   spec.add_dependency "csl-styles", "~> 1.0.1"

--- a/lib/asciidoctor-bibliography/version.rb
+++ b/lib/asciidoctor-bibliography/version.rb
@@ -1,3 +1,3 @@
 module AsciidoctorBibliography
-  VERSION = "0.10.0".freeze
+  VERSION = "0.10.1".freeze
 end


### PR DESCRIPTION
It seems that we are affected by no breaking changes updating `asciidoctor` from `1.*` to `2.*`.
In fact, we're not using much of its internals so we could just relax the requirement.