### PR TITLE
Escape left square brackets on rendered citations

### DIFF
--- a/lib/asciidoctor-bibliography/citation.rb
+++ b/lib/asciidoctor-bibliography/citation.rb
@@ -170,8 +170,8 @@ module AsciidoctorBibliography
     def xref_id(*fragments)
       fragments.compact.join("-")
     end
-  
-  private
+
+    private
 
     def escape_square_brackets(string)
       string.gsub("[", "&lsqb;").gsub("]", "&rsqb;")

--- a/lib/asciidoctor-bibliography/citation.rb
+++ b/lib/asciidoctor-bibliography/citation.rb
@@ -124,7 +124,7 @@ module AsciidoctorBibliography
           # NOTE: this handles custom citation text (slight overkill but easy to extend)
           # NOTE: escaping ] is necessary to safely nest macros (e.g. citing in a footnote)
           (citation_item.text || "{cite}").
-            sub("{cite}", Regexp.last_match[:citation].gsub("]", "&rsqb;"))
+            sub("{cite}", escape_square_brackets(Regexp.last_match[:citation]))
         end
       end
     end
@@ -169,6 +169,12 @@ module AsciidoctorBibliography
 
     def xref_id(*fragments)
       fragments.compact.join("-")
+    end
+  
+  private
+
+    def escape_square_brackets(string)
+      string.gsub("[", "&lsqb;").gsub("]", "&rsqb;")
     end
   end
 end

--- a/lib/asciidoctor-bibliography/version.rb
+++ b/lib/asciidoctor-bibliography/version.rb
@@ -1,3 +1,3 @@
 module AsciidoctorBibliography
-  VERSION = "0.10.1".freeze
+  VERSION = "0.10.2".freeze
 end

--- a/spec/csl/styles/tex_citet_numeric_spec.rb
+++ b/spec/csl/styles/tex_citet_numeric_spec.rb
@@ -7,36 +7,36 @@ describe "citet macro with numeric style" do
 
   it "formats a single citation" do
     expect(formatted_citation("citet:[Erdos65]", options: options)).
-      to eq "Erdős et al. [1&rsqb;"
+      to eq "Erdős et al. &lsqb;1&rsqb;"
   end
 
   it "formats a grouped citation" do
     expect(formatted_citation("citet:[Erdos65]+[Einstein35]", options: options)).
-      to eq "Erdős et al. [1&rsqb;, Einstein et al. [2&rsqb;"
+      to eq "Erdős et al. &lsqb;1&rsqb;, Einstein et al. &lsqb;2&rsqb;"
   end
 
   it "formats a single citation with a prefix" do
     expect(formatted_citation("citet:[Erdos65, prefix=see]", options: options)).
-      to eq "Erdős et al. [see 1&rsqb;"
+      to eq "Erdős et al. &lsqb;see 1&rsqb;"
   end
 
   it "formats a single citation with a suffix" do
     expect(formatted_citation("citet:[Erdos65, suffix=new edition]", options: options)).
-      to eq "Erdős et al. [1, new edition&rsqb;"
+      to eq "Erdős et al. &lsqb;1, new edition&rsqb;"
   end
 
   it "formats a single citation with both a prefix and a suffix" do
     expect(formatted_citation("citet:[Erdos65, prefix=see, suffix=new edition]", options: options)).
-      to eq "Erdős et al. [see 1, new edition&rsqb;"
+      to eq "Erdős et al. &lsqb;see 1, new edition&rsqb;"
   end
 
   it "formats a single citation with a standard locator" do
     expect(formatted_citation("citet:[Erdos65, page=41-43]", options: options)).
-      to eq "Erdős et al. [1, pp. 41-43&rsqb;"
+      to eq "Erdős et al. &lsqb;1, pp. 41-43&rsqb;"
   end
 
   it "formats a single citation with a custom locator" do
     expect(formatted_citation("citet:[Erdos65, locator=somewhere]", options: options)).
-      to eq "Erdős et al. [1, somewhere&rsqb;"
+      to eq "Erdős et al. &lsqb;1, somewhere&rsqb;"
   end
 end

--- a/spec/csl/styles/tex_citets_numeric_spec.rb
+++ b/spec/csl/styles/tex_citets_numeric_spec.rb
@@ -7,36 +7,36 @@ describe "citet* macro with numeric style" do
 
   it "formats a single citation" do
     expect(formatted_citation("citet*:[Erdos65]", options: options)).
-      to eq "Erdős, Heyting, and Brouwer [1&rsqb;"
+      to eq "Erdős, Heyting, and Brouwer &lsqb;1&rsqb;"
   end
 
   it "formats a grouped citation" do
     expect(formatted_citation("citet*:[Erdos65]+[Einstein35]", options: options)).
-      to eq "Erdős, Heyting, and Brouwer [1&rsqb;, Einstein, Podolsky, and Rosen [2&rsqb;"
+      to eq "Erdős, Heyting, and Brouwer &lsqb;1&rsqb;, Einstein, Podolsky, and Rosen &lsqb;2&rsqb;"
   end
 
   it "formats a single citation with a prefix" do
     expect(formatted_citation("citet*:[Erdos65, prefix=see]", options: options)).
-      to eq "Erdős, Heyting, and Brouwer [see 1&rsqb;"
+      to eq "Erdős, Heyting, and Brouwer &lsqb;see 1&rsqb;"
   end
 
   it "formats a single citation with a suffix" do
     expect(formatted_citation("citet*:[Erdos65, suffix=new edition]", options: options)).
-      to eq "Erdős, Heyting, and Brouwer [1, new edition&rsqb;"
+      to eq "Erdős, Heyting, and Brouwer &lsqb;1, new edition&rsqb;"
   end
 
   it "formats a single citation with both a prefix and a suffix" do
     expect(formatted_citation("citet*:[Erdos65, prefix=see, suffix=new edition]", options: options)).
-      to eq "Erdős, Heyting, and Brouwer [see 1, new edition&rsqb;"
+      to eq "Erdős, Heyting, and Brouwer &lsqb;see 1, new edition&rsqb;"
   end
 
   it "formats a single citation with a standard locator" do
     expect(formatted_citation("citet*:[Erdos65, page=41-43]", options: options)).
-      to eq "Erdős, Heyting, and Brouwer [1, pp. 41-43&rsqb;"
+      to eq "Erdős, Heyting, and Brouwer &lsqb;1, pp. 41-43&rsqb;"
   end
 
   it "formats a single citation with a custom locator" do
     expect(formatted_citation("citet*:[Erdos65, locator=somewhere]", options: options)).
-      to eq "Erdős, Heyting, and Brouwer [1, somewhere&rsqb;"
+      to eq "Erdős, Heyting, and Brouwer &lsqb;1, somewhere&rsqb;"
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,0 +1,32 @@
+# coding: utf-8
+
+require "asciidoctor-bibliography"
+
+describe "rendering citations styles containing square brackets" do
+  let(:parsed_document) do
+    Asciidoctor::Document.new(<<~ADOC_INPUT).tap(&:parse)
+      = Sample document
+      :bibliography-database: spec/fixtures/database.bib
+      :bibliography-hyperlinks: true
+      :bibliography-style: ieee
+      ...
+
+      This paragraph contains a citation: cite:[Lane12a].
+      It also contains [.my-class]#some# inline styling.
+    ADOC_INPUT
+  end
+
+  it "does not confuse rendered brackets with macro brackets in the paragraph" do
+    # I.e. we're trying to avoid results like
+    # ```
+    # <p>This paragraph contains a citation: <a href="#bibliography-default-Lane12a"><span class="1&rsqb;</a>.
+    # It also contains [.my-class">some</span> inline styling.</p>
+    # ```
+    expect(parsed_document.render).to eq(<<~HTML_OUTPUT.strip)
+      <div class="paragraph">
+      <p>This paragraph contains a citation: <a href="#bibliography-default-Lane12a">&lsqb;1&rsqb;</a>.
+      It also contains <span class="my-class">some</span> inline styling.</p>
+      </div>
+    HTML_OUTPUT
+  end
+end


### PR DESCRIPTION
When attributes are used in a line *adjacent* and following a rendered citation, the `asciidoctor` parser closes the citations' unescaped left bracket with the attribute's right bracket creating issues like #101 