### PR TITLE
hotfix(dependencies): 🚑️ Upgrading bibtex-ruby version 

### DIFF
--- a/asciidoctor-bibliography.gemspec
+++ b/asciidoctor-bibliography.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
   spec.add_dependency "asciidoctor", ">= 1.5.6"
-  spec.add_dependency "bibtex-ruby", "~> 4.4.4"
+  spec.add_dependency "bibtex-ruby", "~> 6.0.0"
   spec.add_dependency "citeproc-ruby", "~> 1.1.7"
   spec.add_dependency "csl-styles", "~> 1.0.1"
   spec.add_dependency "latex-decode", "~> 0.2.2"


### PR DESCRIPTION
I did that to avoid "tried to create Proc object without a block" error cause of ruby 2.7 (https://blog.saeloun.com/2019/09/02/ruby-2-7-proc-without-block-warning.html)